### PR TITLE
fix opportunity signup unicode issues

### DIFF
--- a/purchasing/opportunities/util.py
+++ b/purchasing/opportunities/util.py
@@ -176,7 +176,7 @@ def signup_for_opp(form, opportunity, multi=False):
         'OPPORTUNITY: {opportunities}'.format(
             email=form.data.get('email'),
             business_name=form.data.get('business_name'),
-            opportunities=', '.join([i.description for i in email_opportunities])
+            opportunities=', '.join([i.title.encode('ascii', 'ignore') for i in email_opportunities])
         )
     )
 


### PR DESCRIPTION
Fix issue where signing up for opportunities with unicode in their descriptions would blow up the logger.
