### PR TITLE
fixed bug with scout/conductor admin list view display

### DIFF
--- a/purchasing/admin/views.py
+++ b/purchasing/admin/views.py
@@ -115,15 +115,35 @@ class ScoutContractAdmin(ContractBaseAdmin):
     def get_query(self):
         '''Override default get query to limit to assigned contracts
         '''
-        return super(ScoutContractAdmin, self).get_query().filter(
-            ContractBase.current_stage_id == None
+        last_stage = db.session.query(
+            Flow.id,
+            Flow.stage_order[db.func.array_upper(Flow.stage_order, 1)].label('last')
+        ).subquery()
+
+        return super(ScoutContractAdmin, self).get_query().outerjoin(
+            last_stage
+        ).filter(
+            db.or_(
+                (ContractBase.current_stage_id == None)
+                (ContractBase.current_stage_id == last_stage.c.last)
+            )
         )
 
     def get_count_query(self):
         '''Override default get count query to conform to above
         '''
-        return super(ScoutContractAdmin, self).get_count_query().filter(
-            ContractBase.current_stage_id == None,
+        last_stage = db.session.query(
+            Flow.id,
+            Flow.stage_order[db.func.array_upper(Flow.stage_order, 1)].label('last')
+        ).subquery()
+
+        return super(ScoutContractAdmin, self).get_count_query().outerjoin(
+            last_stage
+        ).filter(
+            db.or_(
+                (ContractBase.current_stage_id == None)
+                (ContractBase.current_stage_id == last_stage.c.last)
+            )
         )
 
 class ConductorContractStageAdmin(SuperAdminMixin, ContractBaseAdmin):
@@ -171,17 +191,35 @@ class ConductorContractAdmin(ContractBaseAdmin):
     def get_query(self):
         '''Override default get query to limit to assigned contracts
         '''
-        return super(ConductorContractAdmin, self).get_query().filter(
-            ContractBase.current_stage_id != None,
-            ContractBase.is_visible == False,
+        last_stage = db.session.query(
+            Flow.id,
+            Flow.stage_order[db.func.array_upper(Flow.stage_order, 1)].label('last')
+        ).subquery()
+
+        return super(ConductorContractAdmin, self).get_query().outerjoin(
+            last_stage
+        ).filter(
+            db.or_(
+                ContractBase.current_stage_id != last_stage.c.last,
+                ContractBase.current_stage_id != None
+            ), ContractBase.is_visible == False
         )
 
     def get_count_query(self):
         '''Override default get count query to conform to above
         '''
-        return super(ConductorContractAdmin, self).get_count_query().filter(
-            ContractBase.current_stage_id != None,
-            ContractBase.is_visible == False,
+        last_stage = db.session.query(
+            Flow.id,
+            Flow.stage_order[db.func.array_upper(Flow.stage_order, 1)].label('last')
+        ).subquery()
+
+        return super(ConductorContractAdmin, self).get_count_query().outerjoin(
+            last_stage
+        ).filter(
+            db.or_(
+                ContractBase.current_stage_id != last_stage.c.last,
+                ContractBase.current_stage_id != None
+            ), ContractBase.is_visible == False
         )
 
     def create_form(self):

--- a/purchasing_test/integration/opportunities/test_opportunity_admin.py
+++ b/purchasing_test/integration/opportunities/test_opportunity_admin.py
@@ -41,7 +41,7 @@ class TestOpportunitiesAdmin(TestOpportunitiesAdminBase):
             'title': 'NEW_OPPORTUNITY', 'description': 'test',
             'planned_publish': datetime.date.today(),
             'planned_submission_start': datetime.date.today(),
-            'planned_submission_end': datetime.date.today() + datetime.timedelta(1),
+            'planned_submission_end': datetime.date.today() + datetime.timedelta(5),
             'is_public': False, 'subcategories-1': 'on', 'subcategories-2': 'on',
             'subcategories-3': 'on', 'subcategories-4': 'on',
             'opportunity_type': self.opportunity_type.id
@@ -82,7 +82,7 @@ class TestOpportunitiesAdmin(TestOpportunitiesAdminBase):
             'title': 'test', 'description': 'test',
             'planned_publish': datetime.date.today(),
             'planned_submission_start': datetime.date.today(),
-            'planned_submission_end': datetime.date.today() + datetime.timedelta(1),
+            'planned_submission_end': datetime.date.today() + datetime.timedelta(5),
             'is_public': False, 'subcategories-{}'.format(Category.query.first().id): 'on',
             'opportunity_type': self.opportunity_type.id
         }


### PR DESCRIPTION
In the previous setup, contracts were not appearing when they should due to an overly aggressive filter. Previously, only contracts with no current_stage_id would appear in the Scout admin. However, this excluded all completed contracts through conductor. In the new way, contracts with no current_stage_id or a current_stage_id that equals the last stage in that contract's flow will show up.

Fixes #15
