### PR TITLE
Flip email reply to

### DIFF
--- a/purchasing/conductor/metrics/views.py
+++ b/purchasing/conductor/metrics/views.py
@@ -85,6 +85,7 @@ def download_all():
         c.description, c.expiration_date, null as parent_expiration,
         d.name as department, u.email as assigned_to,
         cp.value as spec_number, null as parent_spec,
+        f.flow_name as flow_name,
         CASE
             WHEN c.is_archived is True THEN 'archived'
             WHEN c.is_visible is False THEN 'removed from conductor'
@@ -99,6 +100,8 @@ def download_all():
     ON c.department_id = d.id
     LEFT OUTER JOIN contract_type ct
     ON c.contract_type_id = ct.id
+    LEFT OUTER JOIN flow f
+    on c.flow_id = f.id
     WHERE lower(ct.name) in ('county', 'a-bid', 'b-bid')
     AND lower(cp.key) = 'spec number'
     AND c.parent_id is null
@@ -111,6 +114,7 @@ def download_all():
         c.description, c.expiration_date, p.expiration_date as parent_expiration,
         d.name as department, u.email as assigned_to,
         cp.value as spec_number, pcp.value as parent_spec,
+        f.flow_name as flow_name,
         CASE
             WHEN c.is_archived is True THEN 'archived'
             WHEN c.current_stage_id is null then 'not started'
@@ -130,6 +134,8 @@ def download_all():
     ON c.department_id = d.id
     LEFT OUTER JOIN contract_type ct
     ON c.contract_type_id = ct.id
+    LEFT OUTER JOIN flow f
+    on c.flow_id = f.id
     WHERE lower(ct.name) in ('county', 'a-bid', 'b-bid')
     AND (lower(cp.key) = 'spec number' OR lower(pcp.key) = 'spec number')
     AND c.parent_id is not null

--- a/purchasing/templates/opportunities/emails/biweeklydigest.html
+++ b/purchasing/templates/opportunities/emails/biweeklydigest.html
@@ -25,5 +25,5 @@ The Beacon team
 {% endblock %}
 
 {% block footer %}
-<p><a href="{{ url_for('opportunities.manage', _external=True) }}">Manage your subscription</a> | <a href="mailto:pittsburgh@codeforamerica.org?Subject=Feedback%20from%20Email">Questions? Email us</a>
+<p><a href="{{ url_for('opportunities.manage', _external=True) }}">Manage your subscription</a> | <a href="mailto:procurement@pittsburghpa.gov?Subject=Feedback%20from%20Email">Questions? Email us</a>
 {% endblock %}

--- a/purchasing/templates/opportunities/emails/newopp.html
+++ b/purchasing/templates/opportunities/emails/newopp.html
@@ -16,5 +16,5 @@ The Beacon team
 {% endblock %}
 
 {% block footer %}
-<p><a href="{{ url_for('opportunities.manage', _external=True) }}">Manage your subscription</a> | <a href="mailto:pittsburgh@codeforamerica.org?Subject=Feedback%20from%20Email">Questions? Email us</a>
+<p><a href="{{ url_for('opportunities.manage', _external=True) }}">Manage your subscription</a> | <a href="mailto:procurement@pittsburghpa.gov?Subject=Feedback%20from%20Email">Questions? Email us</a>
 {% endblock %}

--- a/purchasing/templates/opportunities/emails/newopp.txt
+++ b/purchasing/templates/opportunities/emails/newopp.txt
@@ -6,4 +6,4 @@ Thanks,
 The Beacon Team
 
 Manage your subscription: {{ url_for('opportunities.manage', _external=True) }}
-Questions? Email us at pittsburgh@codeforamerica.org
+Questions? Email us at procurement@pittsburghpa.gov

--- a/purchasing/templates/opportunities/emails/oppselected.html
+++ b/purchasing/templates/opportunities/emails/oppselected.html
@@ -9,7 +9,7 @@
  <ul>
   <li><a href="{{ url_for('opportunities.detail', opportunity_id=opportunity.id, _external=True) }}">{{ opportunity.title }}</a></li>
 </ul>
-  {% endfor %}  
+  {% endfor %}
 
 <p>If you’re interested, we invite you to send in a proposal! Stay tuned for reminders about deadlines and opportunities to send in questions.
 </p>
@@ -23,5 +23,5 @@
 {% endblock %}
 
 {% block footer %}
-<p><a href="{{ url_for('opportunities.manage', _external=True) }}">Manage your subscription</a> | <a href="mailto:pittsburgh@codeforamerica.org?Subject=Feedback%20from%20Email">Questions? Email us</a>
+<p><a href="{{ url_for('opportunities.manage', _external=True) }}">Manage your subscription</a> | <a href="mailto:procurement@pittsburghpa.gov?Subject=Feedback%20from%20Email">Questions? Email us</a>
 {% endblock %}

--- a/purchasing/templates/opportunities/emails/oppselected.txt
+++ b/purchasing/templates/opportunities/emails/oppselected.txt
@@ -1,9 +1,9 @@
 Your new Beacon subscription is confirmed.
 
-Thanks for subscribing to: 
+Thanks for subscribing to:
 {% for opportunity in opportunities %}
 - {{ opportunity.title }}: {{ url_for('opportunities.detail', opportunity_id=opportunity.id, _external=True) }}">
-{% endfor %}  
+{% endfor %}
 
 If you’re interested, we invite you to take a look and send in a proposal! Stay tuned for reminders about deadlines and opportunities to send in questions.
 
@@ -12,4 +12,4 @@ Best,
 The Beacon Team
 
 Manage your subscription: {{ url_for('opportunities.manage', _external=True) }}
-Questions? Email us at pittsburgh@codeforamerica.org
+Questions? Email us at procurement@pittsburghpa.gov

--- a/purchasing/templates/opportunities/emails/signup.html
+++ b/purchasing/templates/opportunities/emails/signup.html
@@ -34,5 +34,5 @@
 {% endblock %}
 
 {% block footer %}
-<p><a href="{{ url_for('opportunities.manage', _external=True) }}">Manage your subscription</a> | <a href="mailto:pittsburgh@codeforamerica.org?Subject=Feedback%20from%20Email">Questions? Email us</a>
+<p><a href="{{ url_for('opportunities.manage', _external=True) }}">Manage your subscription</a> | <a href="mailto:procurement@pittsburghpa.gov?Subject=Feedback%20from%20Email">Questions? Email us</a>
 {% endblock %}

--- a/purchasing/templates/opportunities/emails/signup.txt
+++ b/purchasing/templates/opportunities/emails/signup.txt
@@ -26,4 +26,4 @@ Thanks,
 The Beacon team
 
 Manage your subscription: {{ url_for('opportunities.manage', _external=True) }}
-Questions? Email us at pittsburgh@codeforamerica.org
+Questions? Email us at procurement@pittsburghpa.gov

--- a/purchasing_test/integration/admin/test_admin.py
+++ b/purchasing_test/integration/admin/test_admin.py
@@ -1,8 +1,8 @@
 # -*- coding: utf-8 -*-
 
+from flask import current_app
 from purchasing_test.test_base import BaseTestCase
 from purchasing_test.util import insert_a_user, insert_a_role
-from purchasing_test.factories import UserFactory
 
 class TestAdmin(BaseTestCase):
     render_templates = False
@@ -40,3 +40,16 @@ class TestAdmin(BaseTestCase):
         self.assert200(self.client.get('/admin/'))
         self.assert200(self.client.get('/admin/role/'))
         self.assert200(self.client.get('/admin/user-roles/'))
+
+    def test_admin_views(self):
+        self.login_user(self.superadmin_user)
+
+        for rule in current_app.url_map.iter_rules():
+            if not rule.rule.startswith('/admin') or \
+                'ajax' in rule.rule or \
+                'GET' not in rule.methods or \
+                'static' in rule.rule:
+                    continue
+            else:
+                code = self.client.get(rule.rule).status_code
+                self.assertTrue(code in [200, 302])


### PR DESCRIPTION
- Move reply-to emails to procurement@pittsburghpa.gov (@rileystewart can you confirm this is the right email)
- Add basic admin view tests (prevent regression)
- Add flow names to conductor all downloads
