### PR TITLE
include a shutdown notice on all beacon/scout pages

### DIFF
--- a/purchasing/static/less/_styles.less
+++ b/purchasing/static/less/_styles.less
@@ -257,3 +257,9 @@ hr.small {
 .spinner-container {
   padding-top: 30px;
 }
+
+// shutdown notice
+.shutdown-container {
+  margin-top: 22px;
+}
+

--- a/purchasing/static/less/opportunities/_opportunity_detail.less
+++ b/purchasing/static/less/opportunities/_opportunity_detail.less
@@ -10,10 +10,6 @@
   color: white;
 }
 
-.detail-body {
-  margin-top: 40px;
-}
-
 .detail-bid-opening {
   margin-top: 25px;
 }

--- a/purchasing/templates/conductor/layout.html
+++ b/purchasing/templates/conductor/layout.html
@@ -10,6 +10,8 @@
 {% include "conductor/nav.html" %}
 {% endblock %}
 
+{% block shutdown %}{% endblock %}
+
 {% block jsvars %}
 <script type="text/javascript">
 var contractId, activeTab, currentStageEnter, ajaxUrl;

--- a/purchasing/templates/includes/shutdown.html
+++ b/purchasing/templates/includes/shutdown.html
@@ -4,7 +4,7 @@
       <div class="message-container">
         <div class="alert alert-info" role="alert">
           <button type="button" class="close" data-dismiss="alert" aria-label="Close"><span aria-hidden="true">&times;</span></button>
-          The Pittsburgh Purchasing Suite is shutting down as things are moved over to Procurement's new web home on WebProcure. Thank you for three great years of service!
+          This site is no longer being updated. Please refer to the City's new <a href="">contract database</a>. Thank you for three great years of service!
         </div>
       </div>
     </div>

--- a/purchasing/templates/includes/shutdown.html
+++ b/purchasing/templates/includes/shutdown.html
@@ -1,0 +1,12 @@
+<div class="container shutdown-container">
+  <div class="row">
+    <div class="col-md-12">
+      <div class="message-container">
+        <div class="alert alert-info" role="alert">
+          <button type="button" class="close" data-dismiss="alert" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+          The Pittsburgh Purchasing Suite is shutting down as things are moved over to Procurement's new web home on WebProcure. Thank you for three great years of service!
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/purchasing/templates/layout.html
+++ b/purchasing/templates/layout.html
@@ -45,6 +45,9 @@
     {% block content %}
       <div class="container">
         {% include "includes/flashes.html" %}
+        {% block shutdown %}
+          {% include 'includes/shutdown.html' %}
+        {% endblock %}
       </div>
     {% endblock %}
   </div>

--- a/purchasing/templates/layout.html
+++ b/purchasing/templates/layout.html
@@ -43,11 +43,11 @@
 
   <div role="main" class="main">
     {% block content %}
+      {% block shutdown %}
+        {% include 'includes/shutdown.html' %}
+      {% endblock %}
       <div class="container">
         {% include "includes/flashes.html" %}
-        {% block shutdown %}
-          {% include 'includes/shutdown.html' %}
-        {% endblock %}
       </div>
     {% endblock %}
   </div>

--- a/purchasing/templates/opportunities/browse.html
+++ b/purchasing/templates/opportunities/browse.html
@@ -5,6 +5,8 @@
 {% endblock %}
 
 {% block content %}
+{% include 'includes/shutdown.html' %}
+
 <div class="container">
   <div class="row">
     <div class="col-md-8 col-md-offset-2">

--- a/purchasing/templates/opportunities/front/detail.html
+++ b/purchasing/templates/opportunities/front/detail.html
@@ -57,6 +57,8 @@
   </div>
 </div>
 
+{% include 'includes/shutdown.html' %}
+
 <div class="container detail-body">
   <div class="row">
     <div class="col-md-12">

--- a/purchasing/templates/opportunities/front/expired.html
+++ b/purchasing/templates/opportunities/front/expired.html
@@ -5,6 +5,7 @@
 {% endblock %}
 
 {% block content %}
+{% include 'includes/shutdown.html' %}
 
 <div class="container">
   <div class="row">

--- a/purchasing/templates/opportunities/front/manage.html
+++ b/purchasing/templates/opportunities/front/manage.html
@@ -2,6 +2,7 @@
 {% import "macros/with_errors.html" as macros %}
 
 {% block content %}
+{% include 'includes/shutdown.html' %}
 
 <div class="container">
   <div class="row">

--- a/purchasing/templates/opportunities/front/splash.html
+++ b/purchasing/templates/opportunities/front/splash.html
@@ -19,7 +19,7 @@
     </div>
   </div><!-- /splash-header -->
 
-  <div class="spacer-30"></div>
+  {% include 'includes/shutdown.html' %}
 
   <div class="faq-content-container">
     <div class="row">

--- a/purchasing/templates/scout/layout.html
+++ b/purchasing/templates/scout/layout.html
@@ -10,6 +10,7 @@
 {% include "scout/nav.html" %}
 {% endblock %}
 
+
 {% block js %}
   {{ super() }}
   {% assets "scoutjs" %}


### PR DESCRIPTION
This changes introduces a partial that includes a small shutdown notice (whose contents are still TBD). The partial is applied to all Scout and front-facing Beacon pages. It is not added to Beacon-admin or Conductor pages.

cc @hamhands

<img width="1440" alt="screen shot 2018-09-28 at 11 24 49 am" src="https://user-images.githubusercontent.com/1957344/46218016-97984800-c311-11e8-8f57-62cecf084cd3.png">
<img width="1440" alt="screen shot 2018-09-28 at 11 27 40 am" src="https://user-images.githubusercontent.com/1957344/46218017-97984800-c311-11e8-85be-3c7c79917f98.png">
<img width="1439" alt="screen shot 2018-09-28 at 11 27 45 am" src="https://user-images.githubusercontent.com/1957344/46218018-97984800-c311-11e8-9440-2f4853f8d660.png">
<img width="1440" alt="screen shot 2018-09-28 at 11 27 53 am" src="https://user-images.githubusercontent.com/1957344/46218019-97984800-c311-11e8-867f-50d8225813ad.png">
<img width="1440" alt="screen shot 2018-09-28 at 11 27 58 am" src="https://user-images.githubusercontent.com/1957344/46218020-97984800-c311-11e8-971c-243dd2b3f88d.png">
